### PR TITLE
Ontoportal align: Doi creation workflow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'redis-rack-cache', '~> 2.0'
 # Data access (caching)
 gem 'redis'
 gem 'redis-activesupport'
+gem 'redis-store', '1.9.1'
 
 # Monitoring
 gem 'cube-ruby', require: 'cube'
@@ -42,12 +43,13 @@ gem 'haml', '~> 5.2.2' # pin see https://github.com/ncbo/ontologies_api/pull/107
 gem 'redcarpet'
 
 # NCBO gems (can be from a local dev path or from rubygems/git)
-gem 'goo', git: 'https://github.com/ontoportal-lirmm/goo.git', branch: 'development'
+gem 'goo', git: 'https://github.com/ontoportal-lirmm/goo.git', branch: 'master'
 gem 'ncbo_annotator', git: 'https://github.com/ontoportal-lirmm/ncbo_annotator.git', branch: 'master'
 gem 'ncbo_cron', git: 'https://github.com/ontoportal-lirmm/ncbo_cron.git', branch: 'master'
 gem 'ncbo_ontology_recommender', git: 'https://github.com/ncbo/ncbo_ontology_recommender.git', branch: 'master'
 gem 'sparql-client', github: 'ontoportal-lirmm/sparql-client', branch: 'master'
-gem 'ontologies_linked_data', git: 'https://github.com/ontoportal-lirmm/ontologies_linked_data.git', branch: 'development'
+gem 'ontologies_linked_data', git: 'https://github.com/lifewatch-eric/ontologies_linked_data.git', branch: 'ecoportal-ontoportal-reset'
+gem 'request_store'
 
 group :development do
   # bcrypt_pbkdf and ed35519 is required for capistrano deployments when using ed25519 keys; see https://github.com/miloserdow/capistrano-deploy/issues/42

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,24 @@
 GIT
+  remote: https://github.com/lifewatch-eric/ontologies_linked_data.git
+  revision: 7cf430eb13b4af52ec0db2d373a33a55a4f3903b
+  branch: ecoportal-ontoportal-reset
+  specs:
+    ontologies_linked_data (0.0.1)
+      activesupport
+      bcrypt
+      goo
+      json
+      libxml-ruby
+      multi_json
+      oj
+      omni_logger
+      pony
+      rack
+      rack-test
+      rsolr
+      rubyzip
+
+GIT
   remote: https://github.com/ncbo/ncbo_ontology_recommender.git
   revision: d0ac992c88bd417f2f2137ba62934c3c41b6db7c
   branch: master
@@ -11,8 +31,8 @@ GIT
 
 GIT
   remote: https://github.com/ontoportal-lirmm/goo.git
-  revision: cda6aff2338e2a2831e4e7bf716abdf8fa8483d2
-  branch: development
+  revision: e03f6e8f209a3408a348290d76d129743c0f2fed
+  branch: master
   specs:
     goo (0.0.2)
       addressable (~> 2.8)
@@ -52,26 +72,6 @@ GIT
       rufus-scheduler (~> 2.0.24)
 
 GIT
-  remote: https://github.com/ontoportal-lirmm/ontologies_linked_data.git
-  revision: e9b708c40b2b22b935fb48d18ed19de8148fca35
-  branch: development
-  specs:
-    ontologies_linked_data (0.0.1)
-      activesupport
-      bcrypt
-      goo
-      json
-      libxml-ruby
-      multi_json
-      oj
-      omni_logger
-      pony
-      rack
-      rack-test
-      rsolr
-      rubyzip
-
-GIT
   remote: https://github.com/ontoportal-lirmm/sparql-client.git
   revision: aed51baf4106fd0f3d0e3f9238f0aad9406aa3f0
   branch: master
@@ -103,16 +103,16 @@ GEM
     activesupport (3.2.22.5)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
-    addressable (2.8.1)
+    addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     airbrussh (1.4.1)
       sshkit (>= 1.6.1, != 1.7.0)
-    backports (3.23.0)
+    backports (3.24.1)
     bcrypt (3.1.18)
     bcrypt_pbkdf (1.1.0)
     bigdecimal (1.4.2)
     builder (3.2.4)
-    capistrano (3.17.1)
+    capistrano (3.17.3)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -125,7 +125,7 @@ GEM
       capistrano (~> 3.1)
       sshkit (~> 1.3)
     coderay (1.1.3)
-    concurrent-ruby (1.2.0)
+    concurrent-ruby (1.2.2)
     cube-ruby (0.0.3)
     dante (0.2.0)
     date (3.3.3)
@@ -160,8 +160,8 @@ GEM
     ffi (1.15.5)
     get_process_mem (0.2.7)
       ffi (~> 1.0)
-    google-apis-analytics_v3 (0.12.0)
-      google-apis-core (>= 0.9.1, < 2.a)
+    google-apis-analytics_v3 (0.13.0)
+      google-apis-core (>= 0.11.0, < 2.a)
     google-apis-core (0.11.0)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
@@ -171,7 +171,7 @@ GEM
       retriable (>= 2.0, < 4.a)
       rexml
       webrick
-    googleauth (1.3.0)
+    googleauth (1.5.2)
       faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -193,7 +193,7 @@ GEM
     json_pure (2.6.3)
     jwt (2.7.0)
     kgio (2.11.4)
-    libxml-ruby (4.0.0)
+    libxml-ruby (4.1.1)
     logger (1.5.3)
     macaddr (1.7.2)
       systemu (~> 2.6.5)
@@ -206,7 +206,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
+    mime-types-data (3.2023.0218.1)
     mini_mime (1.1.2)
     minitest (4.7.5)
     minitest-stub_any_instance (1.0.3)
@@ -226,9 +226,9 @@ GEM
       net-ssh (>= 2.6.5, < 8.0.0)
     net-smtp (0.3.3)
       net-protocol
-    net-ssh (7.0.1)
+    net-ssh (7.1.0)
     netrc (0.11.0)
-    newrelic_rpm (8.16.0)
+    newrelic_rpm (9.2.2)
     oj (2.18.5)
     omni_logger (0.1.4)
       logger
@@ -249,14 +249,14 @@ GEM
       rack (>= 0.4)
     rack-cors (1.0.6)
       rack (>= 1.6.0)
-    rack-mini-profiler (3.0.0)
+    rack-mini-profiler (3.1.0)
       rack (>= 1.2.0)
     rack-protection (1.5.5)
       rack
-    rack-test (2.0.2)
+    rack-test (2.1.0)
       rack (>= 1.3)
     rack-timeout (0.6.3)
-    raindrops (0.20.0)
+    raindrops (0.20.1)
     rake (10.5.0)
     rdf (1.0.8)
       addressable (>= 2.2)
@@ -274,6 +274,8 @@ GEM
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
+    request_store (1.5.1)
+      rack (>= 1.4)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -316,12 +318,12 @@ GEM
       rack-test
       sinatra (~> 1.4.0)
       tilt (>= 1.3, < 3)
-    sshkit (1.21.3)
+    sshkit (1.21.4)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     systemu (2.6.5)
-    temple (0.10.0)
-    tilt (2.0.11)
+    temple (0.10.2)
+    tilt (2.1.0)
     timeout (0.3.2)
     trailblazer-option (0.1.2)
     tzinfo (2.0.6)
@@ -341,6 +343,7 @@ GEM
     webrick (1.8.1)
 
 PLATFORMS
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -383,6 +386,8 @@ DEPENDENCIES
   redis
   redis-activesupport
   redis-rack-cache (~> 2.0)
+  redis-store (= 1.9.1)
+  request_store
   shotgun!
   simplecov
   simplecov-cobertura

--- a/controllers/admin_controller.rb
+++ b/controllers/admin_controller.rb
@@ -127,6 +127,22 @@ class AdminController < ApplicationController
       halt 204
     end
 
+    get "/doi_requests_list" do
+      reply find_all_identifier_requests
+    end
+
+    #Searches and returns the request with the id passed as parameter
+    get "/doi_request/:id" do
+      error 400, "You must provide the id of the request" if params[:id].nil?
+
+      all_identifier_requests = find_all_identifier_requests
+
+      error 500, "request not found" if all_identifier_requests.nil? || all_identifier_requests.length == 0
+      error 500, "More than one request was found" if all_identifier_requests.length > 1
+
+      reply all_identifier_requests[0]
+    end
+
     private
 
     def process_long_operation(timeout, args)

--- a/controllers/identifier_requests_controller.rb
+++ b/controllers/identifier_requests_controller.rb
@@ -15,7 +15,7 @@ class IdentifierRequestsController < ApplicationController
     get do
       check_last_modified_collection(LinkedData::Models::IdentifierRequest)
       id_requests = IdentifierRequest.where.include(IdentifierRequest.goo_attrs_to_load(includes_param)).all
-      id_requests = id_requests.select { |r| (!r.submission.nil? && !r.submission.ontology.nil? rescue false) }
+      id_requests = id_requests.select { |r| (!r.submission.nil? rescue false) }
       reply id_requests
     end
 

--- a/controllers/identifier_requests_controller.rb
+++ b/controllers/identifier_requests_controller.rb
@@ -1,0 +1,104 @@
+class IdentifierRequestsController < ApplicationController
+
+  get "/ontologies/:acronym/identifier_requests" do
+    acronym = params["acronym"]
+    error 422, "You must provide an existing `acronym` " if acronym.nil? || acronym.empty?
+    reply IdentifierRequest.where(submission: [ontology: [acronym: acronym]])
+                           .include(IdentifierRequest.goo_attrs_to_load(includes_param))
+                           .all
+  end
+
+  namespace "/identifier_requests" do
+
+    ##
+    # Display all IdentifierRequest
+    get do
+      check_last_modified_collection(LinkedData::Models::IdentifierRequest)
+      id_requests = IdentifierRequest.where.include(IdentifierRequest.goo_attrs_to_load(includes_param)).all
+      id_requests = id_requests.select { |r| (!r.submission.nil? && !r.submission.ontology.nil? rescue false) }
+      reply id_requests
+    end
+
+    get "/all_doi_requests" do
+      params["display_context"] = false
+      params["display_links"] = false
+
+      reply IdentifierRequest.where({ requestType: "DOI_CREATE" })
+                             .or({ requestType: "DOI_UPDATE" })
+                             .include(IdentifierRequest.goo_attrs_to_load(includes_param))
+                             .include(requestedBy: [:username, :email])
+                             .include(processedBy: [:username, :email])
+                             .include(submission: [:submissionId, :identifier, :identifierType, ontology: [:acronym]])
+                             .all
+    end
+
+    ##
+    # Display a IdentifierRequest with a specific requestId
+    get "/:requestId" do
+      reply find_identifier_request
+    end
+
+    get "/:requestId/submission" do
+
+      identifier_req_obj = find_identifier_request
+      identifier_req_obj.bring(submission: OntologySubmission.goo_attrs_to_load(includes_param))
+      reply identifier_req_obj.submission
+    end
+
+    get "/:requestId/requestedBy" do
+      identifier_req_obj = find_identifier_request
+      identifier_req_obj.bring(requestedBy: User.goo_attrs_to_load(includes_param))
+      reply identifier_req_obj.requestedBy
+    end
+
+    get "/:requestId/processedBy" do
+      identifier_req_obj = find_identifier_request
+      identifier_req_obj.bring(processedBy: User.goo_attrs_to_load(includes_param))
+      reply identifier_req_obj.processedBy
+    end
+
+    ##
+    # Create a IdentifierRequest
+    post do
+      identifier_request = create_identifier_request
+
+      identifier_request.bring(requestedBy: [:username, :email])
+      identifier_request.bring(submission: [:submissionId, :identifier, :identifierType, ontology: [:acronym, :administeredBy, :acl, :viewingRestriction]])
+
+      reply 201, identifier_request
+    end
+
+    ##
+    # Update an IdentifierRequest
+    patch '/:requestId' do
+      identifier_request = find_identifier_request
+
+      populate_from_params(identifier_request, params)
+      if identifier_request.valid?
+        identifier_request.save
+      else
+        error 422, identifier_request.errors
+      end
+      halt 204
+    end
+
+    # Delete ALL IdentifierRequests
+    delete '/all' do
+      all_identifier_requests = IdentifierRequest.where.all
+      error 422, "No elements was found" if all_identifier_requests.empty?
+
+      all_identifier_requests.each { e.delete }
+      halt 204
+    end
+
+    ##
+    # Delete an IdentifierRequest
+    delete '/:requestId' do
+      identifier_request = find_identifier_request
+      identifier_request.delete
+      halt 204
+    end
+
+  end
+
+end

--- a/helpers/identifier_requests_helper.rb
+++ b/helpers/identifier_requests_helper.rb
@@ -1,0 +1,34 @@
+require 'sinatra/base'
+require_relative '../utils/utils'
+
+module Sinatra
+  module Helpers
+    module IdentifierRequestsHelper
+
+      def find_identifier_request(id = params["requestId"])
+        identifier_req_obj = IdentifierRequest.find(id).include(IdentifierRequest.goo_attrs_to_load(includes_param)).first
+        error 404, "You must provide an existing `requestId`" unless identifier_req_obj
+        identifier_req_obj
+      end
+
+      ##
+      # Create a new OntologySubmission object based on the request data
+      def create_identifier_request
+        params = @params
+        # Create OntologySubmission
+        params["display"] = "all"
+        identifier_request_obj = instance_from_params(IdentifierRequest, params)
+        identifier_request_obj.requestId = IdentifierRequest.identifierRequest_id_generator if (identifier_request_obj.requestId.nil? || identifier_request_obj.requestId.empty?)
+
+        if identifier_request_obj.valid?
+          identifier_request_obj.save
+        else
+          error 400, identifier_request_obj.errors
+        end
+        identifier_request_obj
+      end
+    end
+  end
+end
+
+helpers Sinatra::Helpers::IdentifierRequestsHelper

--- a/helpers/identifier_requests_helper.rb
+++ b/helpers/identifier_requests_helper.rb
@@ -1,5 +1,4 @@
 require 'sinatra/base'
-require_relative '../utils/utils'
 
 module Sinatra
   module Helpers

--- a/helpers/identifier_requests_helper.rb
+++ b/helpers/identifier_requests_helper.rb
@@ -5,6 +5,16 @@ module Sinatra
   module Helpers
     module IdentifierRequestsHelper
 
+      def find_all_identifier_requests
+        all_identifier_requests = IdentifierRequest.where({ requestType: "DOI_CREATE" })
+                                                   .or({ requestType: "DOI_UPDATE" })
+                                                   .include(IdentifierRequest.goo_attrs_to_load(includes_param))
+                                                   .include(requestedBy: [:username, :email],
+                                                            processedBy: [:username, :email],
+                                                            submission: [:submissionId, :identifier, :identifierType, ontology: [:acronym]])
+                                                   .all
+        all_identifier_requests.select { |idReqObj| (!idReqObj.submission.nil? && idReqObj.requestId == params[:id]) }
+      end
       def find_identifier_request(id = params["requestId"])
         identifier_req_obj = IdentifierRequest.find(id).include(IdentifierRequest.goo_attrs_to_load(includes_param)).first
         error 404, "You must provide an existing `requestId`" unless identifier_req_obj

--- a/models/simple_wrappers.rb
+++ b/models/simple_wrappers.rb
@@ -29,3 +29,5 @@ ProvisionalClass = LinkedData::Models::ProvisionalClass
 ProvisionalRelation = LinkedData::Models::ProvisionalRelation
 
 SearchHelper = Sinatra::Helpers::SearchHelper
+
+IdentifierRequest = LinkedData::Models::IdentifierRequest

--- a/test/controllers/test_identifier_request_controller.rb
+++ b/test/controllers/test_identifier_request_controller.rb
@@ -1,0 +1,151 @@
+require_relative '../test_case'
+
+class TestIdentifierRequestController < TestCase
+
+  def setup
+    # Create some test groups
+    @test_group = {acronym: "TEST-GROUP", name: "Test Group", description: "Description of the Test Group"}
+    users = User.all
+    if users.empty?
+      2.times.each do
+        username = "username #{rand}"
+        users << User.new(username: username, email: "#{username}@example.org", password: username +'password').save
+      end
+    end
+
+    @submission = OntologySubmission.where.first
+    if @submission.nil?
+      ont = Ontology.new(acronym: "TEST-1", name:  "TEST-1", administeredBy: [users.first], summaryOnly: true).save
+      @submission = OntologySubmission.new(submissionId: 1,
+                                          ontology: ont,
+                                          hasOntologyLanguage: LinkedData::Models::OntologyFormat.find('OWL').first,
+                                          contact: [LinkedData::Models::Contact.new(email: 'test@test.com', name: 'test').save],
+                                          released: DateTime.now, uploadFilePath: '').save
+    end
+
+    @identifiers = {}
+
+    5.times.each do |i|
+      request_id =  i.to_s
+      @identifiers[request_id] =  {
+        requestId: request_id  ,
+        status: LinkedData::Models::IdentifierRequestStatus::PENDING,
+        requestType: LinkedData::Models::IdentifierRequestType::DOI_CREATE,
+        requestedBy: users.sample,
+        requestDate: DateTime.now,
+        processedBy: users.sample,
+        processingDate: DateTime.tomorrow.to_datetime,
+        message: "message test #{rand}",
+        submission: i < 3 ? @submission : nil
+      }
+    end
+
+    # Make sure these don't exist
+    _delete_identifiers
+
+    # Create them again
+    @identifiers.each do |id, identifier|
+      IdentifierRequest.new(identifier).save
+    end
+  end
+
+  def teardown
+    # Delete groups
+    _delete_identifiers
+  end
+
+  def _delete_identifiers
+    @identifiers.each do |request_id, _|
+      id = IdentifierRequest.find(request_id.to_s).first
+      id.delete unless id.nil?
+      assert IdentifierRequest.find(request_id.to_s).first.nil?
+    end
+  end
+
+  def test_ontology_identifiers
+    @submission.bring(:ontology) if @submission.bring?(:ontology)
+    @submission.ontology.bring(:acronym) if @submission.ontology.bring?(:acronym)
+
+    get "/ontologies/#{@submission.ontology.acronym}/identifier_requests"
+    assert last_response.status == 200
+    ids = MultiJson.load(last_response.body)
+    assert_equal @identifiers.reject{|x, v| v[:submission].nil?}.size, ids.size
+  end
+
+
+  def test_all_identifiers_request
+    get '/identifier_requests'
+    assert last_response.ok?
+    ids = MultiJson.load(last_response.body)
+    assert_equal @identifiers.reject{|x, v| v[:submission].nil?}.size, ids.size
+  end
+
+  def test_all_doi_requests
+    get '/identifier_requests/all_doi_requests'
+    assert last_response.ok?
+    ids = MultiJson.load(last_response.body)
+    assert_equal @identifiers.length, ids.length
+  end
+
+
+  def test_single_doi_request
+    request_id, _ = @identifiers.first
+
+    get "identifier_requests/#{request_id}"
+    assert last_response.ok?
+
+    id = MultiJson.load(last_response.body)
+    assert_equal request_id, id["requestId"]
+  end
+
+  def test_create_new_doi_request
+
+    _, new_doi = @identifiers.first
+    request_id = @identifiers.size
+    new_doi[:requestId] = request_id
+    new_doi[:requestedBy] = new_doi[:requestedBy].id.to_s
+    new_doi[:processedBy] = new_doi[:processedBy].id.to_s
+    @identifiers[request_id] = new_doi
+    post "/identifier_requests", new_doi
+    assert last_response.status == 201
+
+    assert MultiJson.load(last_response.body)["requestId"].eql?(request_id.to_s)
+
+    get "/identifier_requests/#{request_id}"
+    assert last_response.ok?
+    assert MultiJson.load(last_response.body)["requestId"].eql?(request_id.to_s)
+  end
+
+  def test_update_patch_doi_request
+    id = IdentifierRequest.where.include(:message, :status, :requestId).first
+
+    new_values ={
+      message: "new message",
+      status: LinkedData::Models::IdentifierRequestStatus::SATISFIED
+    }
+
+    refute_equal new_values[:message], id.message
+    refute_equal new_values[:status], id.status
+
+    patch "/identifier_requests/#{id.requestId}", MultiJson.dump(new_values), "CONTENT_TYPE" => "application/json"
+    assert last_response.status == 204
+
+    get "/identifier_requests/#{id.requestId}"
+    assert last_response.status == 200
+    new_id = MultiJson.load(last_response.body)
+    assert new_id["message"].eql?(new_values[:message])
+    assert new_id["status"].eql?(new_values[:status])
+  end
+
+  def test_delete_doi_request
+    id = IdentifierRequest.where.include(:message, :status, :requestId).first
+    @identifiers.delete(id.requestId)
+    delete "/identifier_requests/#{id.requestId}"
+    assert last_response.status == 204
+
+    get "/identifier_requests/#{id.requestId}"
+    assert last_response.status == 404
+  end
+
+
+end


### PR DESCRIPTION
### Description

This PR adds the following endpoints with there unit tests 

- for the admins, they added the following endpoints
    - `get "/doi_requests_list”`
    - `get "/doi_request/:id”`
- Identifier_requests controller (`namespace "/identifier_requests”`)
    - Display all IdentifierRequest
    - Display all IdentifierRequest by ontology
    - Get "/all_doi_requests”
    - Get "/:requestId” : display a IdentifierRequest with a specific requestId
    - Get "/:requestId/submission”
    - Get "/:requestId/requestedBy”
    - Get "/:requestId/processedBy”
    - Create a IdentifierRequest
    - Update an IdentifierRequest
    - Delete ALL IdentifierRequests
    - Delete an IdentifierRequest

### Changes

- Add identifier request controller and helpers (https://github.com/lifewatch-eric/ontologies_api/pull/5/commits/2f903bd4a543e8545249a7149f39f2673bb31c57)
- Add identifier request admin endpoint (https://github.com/lifewatch-eric/ontologies_api/pull/5/commits/d935a4bf55641892fe8858d4e067f21d220393a7)
- Add identifier request endpoints tests (https://github.com/lifewatch-eric/ontologies_api/pull/5/commits/96180e0a67b7809a50b97653f476034d474abca0)