### PR TITLE
Fix: update datacite mapping of title and publication

### DIFF
--- a/helpers/concerns/data_cite_metadata_exporter.rb
+++ b/helpers/concerns/data_cite_metadata_exporter.rb
@@ -4,7 +4,7 @@ module Sinatra
 
       def to_date_cite(sub)
         hash  = {
-          url: sub.publication.first&.to_s,
+          url: sub.publication.first ? sub.publication.first&.to_s : sub.URI&.to_s,
           version: sub.version,
           description: sub.description,
           publicationYear: sub.released&.year,
@@ -12,7 +12,7 @@ module Sinatra
           creators: to_data_cite_creators(sub.hasCreator),
           identifier: search_doi(sub.identifier) || sub.identifier.first&.to_s,
           identifierType: identifier_type(sub),
-          titles: sub.alternative.map { |x| { title: x, titleType: 'AlternativeTitle' } },
+          titles: [{title: sub.ontology.name, titleType: ''}] + sub.alternative.map { |x| { title: x, titleType: 'AlternativeTitle' } },
           resourceTypeGeneral: 'Dataset',
           resourceType: sub.isOfType.to_s.split('/').last
         }

--- a/test/controllers/test_ontology_submissions_controller.rb
+++ b/test/controllers/test_ontology_submissions_controller.rb
@@ -298,8 +298,13 @@ class TestOntologySubmissionsController < TestCase
 
     assert_equal sub.publication.first.to_s, hash["url"]
 
-    assert_equal sub.alternative.sort, hash["titles"].map{|x| x["title"]}.sort
-    assert_equal ['AlternativeTitle'], hash["titles"].map{|x| x["titleType"]}.uniq
+    if hash['ontology']
+      titles = sub.alternative.sort
+    else
+      titles = [sub.ontology.bring(:name).name] + sub.alternative.sort
+    end
+    assert_equal titles, hash["titles"].map{|x| x["title"]}.sort
+    assert_equal ['AlternativeTitle'], hash["titles"].map{|x| x["titleType"]}.reject(&:empty?).uniq
 
 
 


### PR DESCRIPTION
This PR, updates the datacite properties mapping of `url` and `tiltes`, to prevent the DOI requesting not working if missing.

Now they are as follow:
* Datacite URL = ontology publication or  ontology URI
* Datacite titles = ontology name + ontology alternative names 
 