### PR TITLE
Fix: Vocbench connector by adding an adapter to the old EcoPortal model to the new 

### DIFF
--- a/helpers/ontology_helper.rb
+++ b/helpers/ontology_helper.rb
@@ -1,18 +1,20 @@
 require 'sinatra/base'
 require 'json'
+require_relative 'concerns/ecoportal_metadata_exporter'
 
 module Sinatra
   module Helpers
     module OntologyHelper
-
-      #ISO_LANGUAGE_LIST = ::JSON.parse(IO.read("public/language_iso-639-1.json"))
+      include Sinatra::Concerns::EcoPortalMetadataExporter
 
       ##
       # Create a new OntologySubmission object based on the request data
       def create_submission(ont)
         params = @params
-
         submission_id = ont.next_submission_id
+
+        # VocBench adapter
+        params = old_eco_portal_adapter(params, ont)
 
         # Create OntologySubmission
         ont_submission = instance_from_params(OntologySubmission, params)
@@ -28,16 +30,6 @@ module Sinatra
           ont_submission.hasOntologyLanguage = OntologyFormat.find(params["hasOntologyLanguage"]).first
         end
 
-        # Check if the naturalLanguage provided is a valid ISO-639-1 code (not used anymore, we let lexvo URI)
-=begin
-        if !ont_submission.naturalLanguage.nil?
-          if ISO_LANGUAGE_LIST.has_key?(ont_submission.naturalLanguage.downcase)
-            ont_submission.naturalLanguage = ont_submission.naturalLanguage.downcase
-          else
-            error 422, "You must specify a valid 2 digits language code (ISO-639-1) for naturalLanguage"
-          end
-        end
-=end
 
         if ont_submission.valid?
           ont_submission.save


### PR DESCRIPTION
This PR fixes the Vocbench connector to Ecoportal, by making it consume the old model sent by Vocbench and convert it to the new one. 
Below is an example of the data sent by Vocbench and in the comment the thing that needs to be adapted 

```ruby 
{
 #good
 "acronym"=>"SYPHAX_TEST_VOC",
 #good
 "description"=>"test new description", 
 #good
 "version"=>"2.0.0", 
 #good
 "hasOntologyLanguage"=>"OWL", 
 #good
 "status"=>"alpha", 
 #good
 "released"=>"2001-02-12", 
 #good
 "contact"=> 
  [{"name"=>"syphax", "email"=>"bouazounisyphax@gmail.com"}, {"name"=>"syphax2", "email"=>"gs_bouazouni@esi.dz"}],
 
 #good
 "homepage"=>"https://ecoportal.lifewatchdev.eu/ontologies/SYPHAX_TEST_VOC",
 
 #good
 "documentation"=>"https://ecoportal.lifewatchdev.eu/ontologies/SYPHAX_TEST_VOC",
 
 #not good, need to be a list -> fixed 
 "publication"=>"https://ecoportal.lifewatchdev.eu/ontologies/SYPHAX_TEST_VOC",
 
 #not good, replaced with hasCreator, and need to serach, find or create. 
 "creators"=>[{"creatorName"=>"syphax bouazzouni"}],
 
 #not good, replaced with alternative, and remove "lang" and "titleType" -> fixed
 "titles"=>
  [{"title"=>"Test syphax for vocbench", "lang"=>"en", "titleType"=>"AlternativeTitle"},
   {"title"=>"Syphax test for vocbench", "lang"=>"en", "titleType"=>"AlternativeTitle"}],
 
 #not good, need to be a list, and need to search, find or create an Agent.
 "publisher"=>"lifewatch",
 
 #not good, removed, reduced from "released"  -> fixed 
 "publicationYear"=>"2022",
 
 #not good, replaced with isOfType and need to be a URI -> fixed
 "resourceType"=>"Ontology",
 
 #not good, removed, as always equal "Dataset"  -> fixed
 "resourceTypeGeneral"=>"Dataset",
 
 # URI is required now
 }
```